### PR TITLE
Make version start with 0.1

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
 	<PropertyGroup>
-		<MinVerMinimumMajorMinor>1.0</MinVerMinimumMajorMinor>
+		<MinVerMinimumMajorMinor>0.1</MinVerMinimumMajorMinor>
 		<MinVerAutoIncrement>minor</MinVerAutoIncrement>
 	</PropertyGroup>
 


### PR DESCRIPTION
Discussed with @dvdstelt and since our target version for the first release will be 0.X.0 we decided to start at 0.1

The upside of 0.X over 1.0.0-preview.X is that customers will find the package even if they don't have the "Include prereleases" box ticked in the nuget UI