### PR TITLE
Make sure packages are uploaded on CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
       - name: Build
         run: dotnet build src --configuration Release
       - name: Upload packages
-        if: matrix.name == 'Windows'
         uses: actions/upload-artifact@v3
         with:
           name: NuGet packages


### PR DESCRIPTION
The name will never be "windows" so packages where not upload. Not sure if there is any drawback of always uploading?

