### PR TITLE
Apply address default when finalizing configuration

### DIFF
--- a/src/NServiceBus.Transport.Bridge/Configuration/BridgeConfiguration.cs
+++ b/src/NServiceBus.Transport.Bridge/Configuration/BridgeConfiguration.cs
@@ -6,6 +6,7 @@
     using System.Linq;
     using System.Text;
     using Microsoft.Extensions.Logging;
+    using NServiceBus.Transport;
 
     /// <summary>
     /// Configuration options for bridging multiple transports
@@ -148,6 +149,17 @@
             foreach (var transportConfiguration in transportConfigurations)
             {
                 transportConfiguration.TransportDefinition.TransportTransactionMode = transportTransactionMode;
+
+                foreach (var endpoint in transportConfiguration.Endpoints)
+                {
+                    if (string.IsNullOrEmpty(endpoint.QueueAddress))
+                    {
+#pragma warning disable CS0618 // Type or member is obsolete
+                        endpoint.QueueAddress = transportConfiguration.TransportDefinition
+                            .ToTransportAddress(new QueueAddress(endpoint.Name));
+#pragma warning restore CS0618 // Type or member is obsolete
+                    }
+                }
             }
 
             return new FinalizedBridgeConfiguration(transportConfigurations);

--- a/src/NServiceBus.Transport.Bridge/Configuration/BridgeEndpoint.cs
+++ b/src/NServiceBus.Transport.Bridge/Configuration/BridgeEndpoint.cs
@@ -11,7 +11,7 @@
         /// <summary>
         /// Initializes an endpoint in the transport bridge with the given name
         /// </summary>
-        public BridgeEndpoint(string name) : this(name, name)
+        public BridgeEndpoint(string name) : this(name, null)
         {
         }
 
@@ -53,7 +53,7 @@
 
         internal string Name { get; private set; }
 
-        internal string QueueAddress { get; private set; }
+        internal string QueueAddress { get; set; }
 
         internal List<Subscription> Subscriptions { get; set; }
 

--- a/src/NServiceBus.Transport.Bridge/Configuration/BridgeTransport.cs
+++ b/src/NServiceBus.Transport.Bridge/Configuration/BridgeTransport.cs
@@ -47,10 +47,7 @@
         /// </summary>
         public void HasEndpoint(string endpointName)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
-            var endpointAddress = TransportDefinition.ToTransportAddress(new QueueAddress(endpointName));
-#pragma warning restore CS0618 // Type or member is obsolete
-            HasEndpoint(new BridgeEndpoint(endpointName, endpointAddress));
+            HasEndpoint(new BridgeEndpoint(endpointName));
         }
 
         /// <summary>


### PR DESCRIPTION
Like discussed in slack this makes sure that we properly default the endpoint address if the user hasn't specified a custom address