### PR TITLE
Fixes the ability to bridge audit messages

### DIFF
--- a/src/AcceptanceTests/Shared/Audit.cs
+++ b/src/AcceptanceTests/Shared/Audit.cs
@@ -1,0 +1,118 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using NServiceBus;
+using NServiceBus.AcceptanceTesting;
+using NServiceBus.AcceptanceTesting.Customization;
+using NUnit.Framework;
+using Conventions = NServiceBus.AcceptanceTesting.Customization.Conventions;
+
+public class Audit : BridgeAcceptanceTest
+{
+    [Test]
+    public async Task Should_forward_audit_messages_by_not_modify_message()
+    {
+        var ctx = await Scenario.Define<Context>()
+            .WithEndpoint<PublishingEndpoint>(b => b
+                .When(c => TransportBeingTested.SupportsPublishSubscribe || c.SubscriberSubscribed, (session, c) =>
+                {
+                    return session.Publish(new MessageToBeAudited());
+                }))
+            .WithEndpoint<ProcessingEndpoint>()
+            .WithEndpoint<AuditSpy>()
+            .WithBridge(bridgeConfiguration =>
+            {
+                var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
+                bridgeTransport.AddTestEndpoint<PublishingEndpoint>();
+                bridgeTransport.AddTestEndpoint<AuditSpy>();
+                bridgeConfiguration.AddTransport(bridgeTransport);
+
+                var subscriberEndpoint =
+                    new BridgeEndpoint(Conventions.EndpointNamingConvention(typeof(ProcessingEndpoint)));
+                subscriberEndpoint.RegisterPublisher<MessageToBeAudited>(
+                    Conventions.EndpointNamingConvention(typeof(PublishingEndpoint)));
+                bridgeConfiguration.AddTestTransportEndpoint(subscriberEndpoint);
+            })
+            .Done(c => c.MessageAudited)
+            .Run();
+
+        Assert.IsTrue(ctx.MessageAudited);
+        foreach (var header in ctx.AuditMessageHeaders)
+        {
+            if (ctx.ReceivedMessageHeaders.TryGetValue(header.Key, out var receivedHeaderValue))
+            {
+                Assert.AreEqual(header.Value, receivedHeaderValue,
+                    $"{header.Key} is not the same on processed message and audit message.");
+            }
+        }
+    }
+
+    public class PublishingEndpoint : EndpointConfigurationBuilder
+    {
+        public PublishingEndpoint() =>
+            EndpointSetup<DefaultServer>(c =>
+            {
+                c.OnEndpointSubscribed<Context>((_, ctx) =>
+                {
+                    ctx.SubscriberSubscribed = true;
+                });
+                c.ConfigureRouting().RouteToEndpoint(typeof(MessageToBeAudited), typeof(ProcessingEndpoint));
+            });
+    }
+
+    public class ProcessingEndpoint : EndpointConfigurationBuilder
+    {
+        public ProcessingEndpoint() => EndpointSetup<DefaultTestServer>(
+            c => c.AuditProcessedMessagesTo("Audit.AuditSpy"));
+
+        public class MessageHandler : IHandleMessages<MessageToBeAudited>
+        {
+            readonly Context testContext;
+
+            public MessageHandler(Context context) => testContext = context;
+
+            public Task Handle(MessageToBeAudited message, IMessageHandlerContext context)
+            {
+                testContext.ReceivedMessageHeaders =
+                    new ReadOnlyDictionary<string, string>((IDictionary<string, string>)context.MessageHeaders);
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    public class AuditSpy : EndpointConfigurationBuilder
+    {
+        public AuditSpy()
+        {
+            var endpoint = EndpointSetup<DefaultServer>(c => c.AutoSubscribe().DisableFor<MessageToBeAudited>());
+        }
+
+        class AuditMessageHander : IHandleMessages<MessageToBeAudited>
+        {
+            public AuditMessageHander(Context context) => testContext = context;
+
+            public Task Handle(MessageToBeAudited message, IMessageHandlerContext context)
+            {
+                testContext.MessageAudited = true;
+                testContext.AuditMessageHeaders =
+                    new ReadOnlyDictionary<string, string>((IDictionary<string, string>)context.MessageHeaders);
+
+                return Task.CompletedTask;
+            }
+
+            readonly Context testContext;
+        }
+    }
+
+    public class Context : ScenarioContext
+    {
+        public bool SubscriberSubscribed { get; set; }
+        public bool MessageAudited { get; set; }
+        public IReadOnlyDictionary<string, string> ReceivedMessageHeaders { get; set; }
+        public IReadOnlyDictionary<string, string> AuditMessageHeaders { get; set; }
+    }
+
+    public class MessageToBeAudited : IEvent
+    {
+    }
+}

--- a/src/NServiceBus.Transport.Bridge/MessageShovel.cs
+++ b/src/NServiceBus.Transport.Bridge/MessageShovel.cs
@@ -56,7 +56,7 @@ class MessageShovel
     }
 
     // Assuming that a message is an audit message if a ProcessingMachine is known
-    static bool IsAuditMessage(OutgoingMessage messageToSend) => messageToSend.Headers.ContainsKey(Headers.ProcessingMachine);
+    static bool IsAuditMessage(OutgoingMessage messageToSend) => messageToSend.Headers.ContainsKey(Headers.ProcessingEnded);
 
     void TransformAddressHeader(
         OutgoingMessage messageToSend,


### PR DESCRIPTION
Fixes:

- https://github.com/Particular/NServiceBus.Transport.Bridge/issues/159

Every time a message is bridged, we transform a few headers, with one of them being the `ReplyToAddress` header. With audit messages, these are the already transformed.
With audit messages, we should skip transforming the queue-name or modifying any other headers and immediately forward the message to the audit queue.