### PR TITLE
Fixed wirecompatbility issue with RegisterPublisher which was incorrectly using Type.Fullname instead of Type.AssemblyQualifiedName

### DIFF
--- a/src/NServiceBus.Transport.Bridge/Configuration/BridgeConfiguration.cs
+++ b/src/NServiceBus.Transport.Bridge/Configuration/BridgeConfiguration.cs
@@ -95,7 +95,7 @@
                 sb.AppendLine();
                 foreach (var eventType in eventsWithNoRegisteredPublisher)
                 {
-                    sb.AppendLine($"- {eventType.EventTypeFullName}, publisher: {eventType.Publisher}");
+                    sb.AppendLine($"- {eventType.EventTypeAssemblyQualifiedName}, publisher: {eventType.Publisher}");
                 }
                 throw new InvalidOperationException(sb.ToString());
             }
@@ -103,7 +103,7 @@
             var eventsWithMultiplePublishers = transportConfigurations
                 .SelectMany(t => t.Endpoints)
                 .SelectMany(e => e.Subscriptions)
-                .GroupBy(e => e.EventTypeFullName)
+                .GroupBy(e => e.EventTypeAssemblyQualifiedName)
                 .Where(g => g.GroupBy(s => s.Publisher).Count() > 1);
 
             if (eventsWithMultiplePublishers.Any())

--- a/src/NServiceBus.Transport.Bridge/Configuration/BridgeEndpoint.cs
+++ b/src/NServiceBus.Transport.Bridge/Configuration/BridgeEndpoint.cs
@@ -55,12 +55,12 @@
         /// <summary>
         /// Registers the publisher of the given event type using its assembly fully-qualified name
         /// </summary>
-        public void RegisterPublisher(string eventTypeFullName, string publisher)
+        public void RegisterPublisher(string eventTypeAssemblyQualifiedName, string publisher)
         {
-            Guard.AgainstNullAndEmpty(nameof(eventTypeFullName), eventTypeFullName);
+            Guard.AgainstNullAndEmpty(nameof(eventTypeAssemblyQualifiedName), eventTypeAssemblyQualifiedName);
             Guard.AgainstNullAndEmpty(nameof(publisher), publisher);
 
-            Subscriptions.Add(new Subscription(eventTypeFullName, publisher));
+            Subscriptions.Add(new Subscription(eventTypeAssemblyQualifiedName, publisher));
         }
 
         internal string Name { get; private set; }

--- a/src/NServiceBus.Transport.Bridge/Configuration/BridgeEndpoint.cs
+++ b/src/NServiceBus.Transport.Bridge/Configuration/BridgeEndpoint.cs
@@ -49,7 +49,7 @@
             Guard.AgainstNull(nameof(eventType), eventType);
             Guard.AgainstNullAndEmpty(nameof(publisher), publisher);
 
-            RegisterPublisher(eventType.FullName, publisher);
+            RegisterPublisher(eventType.AssemblyQualifiedName, publisher);
         }
 
         /// <summary>
@@ -73,11 +73,11 @@
         {
             public Subscription(string eventTypeFullName, string publisher)
             {
-                EventTypeFullName = eventTypeFullName;
+                EventTypeAssemblyQualifiedName = eventTypeFullName;
                 Publisher = publisher;
             }
 
-            public string EventTypeFullName { get; private set; }
+            public string EventTypeAssemblyQualifiedName { get; private set; }
 
             public string Publisher { get; private set; }
         }

--- a/src/NServiceBus.Transport.Bridge/Configuration/BridgeEndpoint.cs
+++ b/src/NServiceBus.Transport.Bridge/Configuration/BridgeEndpoint.cs
@@ -53,7 +53,7 @@
         }
 
         /// <summary>
-        /// Registers the publisher of the given event type using its fully-qualified type name
+        /// Registers the publisher of the given event type using its assembly fully-qualified name
         /// </summary>
         public void RegisterPublisher(string eventTypeFullName, string publisher)
         {
@@ -71,9 +71,9 @@
 
         internal class Subscription
         {
-            public Subscription(string eventTypeFullName, string publisher)
+            public Subscription(string eventTypeAssemblyQualifiedName, string publisher)
             {
-                EventTypeAssemblyQualifiedName = eventTypeFullName;
+                EventTypeAssemblyQualifiedName = eventTypeAssemblyQualifiedName;
                 Publisher = publisher;
             }
 

--- a/src/NServiceBus.Transport.Bridge/Configuration/BridgeEndpoint.cs
+++ b/src/NServiceBus.Transport.Bridge/Configuration/BridgeEndpoint.cs
@@ -69,7 +69,18 @@
             Guard.AgainstNullAndEmpty(nameof(eventTypeAssemblyQualifiedName), eventTypeAssemblyQualifiedName);
             Guard.AgainstNullAndEmpty(nameof(publisher), publisher);
 
-            Subscriptions.Add(new Subscription(eventTypeAssemblyQualifiedName, publisher));
+            try
+            {
+                // Try retrieving type, this will validate the assembly qualified name. A value cannot
+                // be parsed it will throw. If it can be parsed it doesn't mean the type can be
+                // resolved thus the result is ignored.
+                _ = Type.GetType(eventTypeAssemblyQualifiedName, false);
+                Subscriptions.Add(new Subscription(eventTypeAssemblyQualifiedName, publisher));
+            }
+            catch
+            {
+                throw new ArgumentException("The event type assembly qualified name is invalid", eventTypeAssemblyQualifiedName);
+            }
         }
 
         internal string Name { get; private set; }

--- a/src/NServiceBus.Transport.Bridge/Configuration/BridgeEndpoint.cs
+++ b/src/NServiceBus.Transport.Bridge/Configuration/BridgeEndpoint.cs
@@ -49,11 +49,20 @@
             Guard.AgainstNull(nameof(eventType), eventType);
             Guard.AgainstNullAndEmpty(nameof(publisher), publisher);
 
-            RegisterPublisher(eventType.AssemblyQualifiedName, publisher);
+            var fullyQualifiedAssemblyTypeName = eventType.AssemblyQualifiedName;
+
+            const string NeutralSuffix = ", Culture=neutral, PublicKeyToken=null";
+
+            if (fullyQualifiedAssemblyTypeName.EndsWith(NeutralSuffix))
+            {
+                fullyQualifiedAssemblyTypeName = fullyQualifiedAssemblyTypeName.Substring(0, fullyQualifiedAssemblyTypeName.Length - NeutralSuffix.Length);
+            }
+
+            RegisterPublisher(fullyQualifiedAssemblyTypeName, publisher);
         }
 
         /// <summary>
-        /// Registers the publisher of the given event type using its assembly fully-qualified name
+        /// Registers the publisher of the given event type using its assembly fully-qualified name i.e `MyNamespace.EventName, AssemblyName, Version=1.0.0.0` (the culture and public keys are ignored by NServiceBus)
         /// </summary>
         public void RegisterPublisher(string eventTypeAssemblyQualifiedName, string publisher)
         {

--- a/src/NServiceBus.Transport.Bridge/SubscriptionManager.cs
+++ b/src/NServiceBus.Transport.Bridge/SubscriptionManager.cs
@@ -38,7 +38,7 @@ class SubscriptionManager
         var eventTypes = new List<MessageMetadata>();
         foreach (var subscription in subscriptions)
         {
-            var eventType = TypeGenerator.GetType(subscription.EventTypeFullName);
+            var eventType = TypeGenerator.GetType(subscription.EventTypeAssemblyQualifiedName);
 
             eventTypes.Add(new MessageMetadata(eventType));
         }
@@ -63,7 +63,7 @@ class SubscriptionManager
         var localAddress = endpointProxy.TransportAddress;
         var subscriptionMessage = ControlMessageFactory.Create(MessageIntent.Subscribe);
 
-        subscriptionMessage.Headers[Headers.SubscriptionMessageType] = subscription.EventTypeFullName + ",Version=1.0.0";
+        subscriptionMessage.Headers[Headers.SubscriptionMessageType] = subscription.EventTypeAssemblyQualifiedName;
         subscriptionMessage.Headers[Headers.ReplyToAddress] = localAddress;
         subscriptionMessage.Headers[Headers.SubscriberTransportAddress] = localAddress;
 
@@ -81,7 +81,7 @@ class SubscriptionManager
         }
         catch (QueueNotFoundException ex)
         {
-            var message = $"Failed to subscribe to {subscription.EventTypeFullName} at publisher queue {subscription.Publisher}, reason {ex.Message}";
+            var message = $"Failed to subscribe to {subscription.EventTypeAssemblyQualifiedName} at publisher queue {subscription.Publisher}, reason {ex.Message}";
             throw new QueueNotFoundException(subscription.Publisher, message, ex);
         }
     }

--- a/src/UnitTests/ApprovalFiles/APIApprovals.PublicApi.approved.txt
+++ b/src/UnitTests/ApprovalFiles/APIApprovals.PublicApi.approved.txt
@@ -11,7 +11,7 @@ namespace NServiceBus
     {
         public BridgeEndpoint(string name) { }
         public BridgeEndpoint(string name, string queueAddress) { }
-        public void RegisterPublisher(string eventTypeFullName, string publisher) { }
+        public void RegisterPublisher(string eventTypeAssemblyQualifiedName, string publisher) { }
         public void RegisterPublisher(System.Type eventType, string publisher) { }
         public void RegisterPublisher<T>(string publisher) { }
     }

--- a/src/UnitTests/BridgeEndpointConfigurationTests.cs
+++ b/src/UnitTests/BridgeEndpointConfigurationTests.cs
@@ -12,10 +12,10 @@ public class BridgeEndpointConfigurationTests
         endpoint.RegisterPublisher<MyEvent>("Billing");
         endpoint.RegisterPublisher(typeof(MyOtherEvent), "Shipping");
 
-        var billingSubscription = endpoint.Subscriptions.SingleOrDefault(t => t.EventTypeFullName == typeof(MyEvent).FullName);
+        var billingSubscription = endpoint.Subscriptions.SingleOrDefault(t => t.EventTypeAssemblyQualifiedName == typeof(MyEvent).AssemblyQualifiedName);
         Assert.AreEqual("Billing", billingSubscription.Publisher);
 
-        var shippingSubscription = endpoint.Subscriptions.SingleOrDefault(t => t.EventTypeFullName == typeof(MyOtherEvent).FullName);
+        var shippingSubscription = endpoint.Subscriptions.SingleOrDefault(t => t.EventTypeAssemblyQualifiedName == typeof(MyOtherEvent).AssemblyQualifiedName);
         Assert.AreEqual("Shipping", shippingSubscription.Publisher);
 
     }


### PR DESCRIPTION
Subscriptions were incorrectly using `Type.Fullname` instead of `Type.AssemblyQualifiedName` resulting in wire incompatibility for major versions of core that do not have fuzzy type matching on subscriptions.

This also removes the appending of the ` + ",Version=1.0.0"` hack as the assembly version could actually be different and this information should be based on `Type.AssemblyQualifiedName`.

A test cannot be added as it was already compatible with the latest MSMQ transport but its incompatible with for example NServiceBus 4.x

Improved docs related to this PR:

- https://github.com/Particular/docs.particular.net/pull/6091